### PR TITLE
Feature/quiz/add-transaction-support

### DIFF
--- a/crear_encuesta/procesar_crear.php
+++ b/crear_encuesta/procesar_crear.php
@@ -1,55 +1,86 @@
 <?php
+// INICIAR LA SESION PARA ACCEDER A VARIABLES DE SESION
 session_start();
-//debe de iniciar sesion para poder accede a crear encuesta
+
+// VERIFICAR SI EL USUARIO HA INICIADO SESION, SI NO REDIRIGIR AL LOGIN
 if (!isset($_SESSION['id_usuario'])) {
     header("Location: ../login/login.html");
     exit();
 }
 
+// INCLUIR ARCHIVO DE CONEXION A LA BASE DE DATOS
 include '../conexion.php';
-//metodo post  para enviar los datos a la base de datos 
+
+// VERIFICAR QUE EL METODO DE LA SOLICITUD SEA POST
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
+    // OBTENER Y LIMPIAR EL TITULO Y LA DESCRIPCION DEL FORMULARIO
     $titulo = trim($_POST['titulo']);
     $descripcion = trim($_POST['descripcion']);
+
+    // OBTENER LAS PREGUNTAS DEL FORMULARIO (SI NO HAY, USAR ARRAY VACIO)
     $preguntas = $_POST['preguntas'] ?? [];
 
-    if (empty($titulo) || empty($descripcion) || count($preguntas) == 0) {
+    // VERIFICAR QUE EL TITULO, LA DESCRIPCION Y LAS PREGUNTAS NO ESTEN VACIOS
+    if (empty($titulo) || empty($descripcion) || count($preguntas) === 0) {
         die("Debes completar el título, la descripción y al menos una pregunta.");
     }
 
-    // insertamos la encuesta en la tabla 
-    $sql_encuesta = "INSERT INTO encuestas (titulo, descripcion, creador_id) VALUES (?, ?, ?)";
-    $stmt = $conn->prepare($sql_encuesta);
-    $stmt->bind_param("ssi", $titulo, $descripcion, $_SESSION['id_usuario']);
-    $stmt->execute();
-    $id_encuesta = $stmt->insert_id;
+    // INICIAR UNA TRANSACCION PARA GARANTIZAR ATOMICIDAD
+    $conn->begin_transaction();
 
-    // y aqui insertamos las preguntas y respuestas en distintas tablas 
-    foreach ($preguntas as $index => $textoPregunta) {
-        $sql_pregunta = "INSERT INTO preguntas (id_encuesta, texto) VALUES (?, ?)";
-        $stmt_pregunta = $conn->prepare($sql_pregunta);
-        $stmt_pregunta->bind_param("is", $id_encuesta, $textoPregunta);
-        $stmt_pregunta->execute();
-        $id_pregunta = $stmt_pregunta->insert_id;
+    try {
+        // INSERTAR LA ENCUESTA EN LA TABLA `encuestas`
+        $sql_encuesta = "INSERT INTO encuestas (titulo, descripcion, creador_id) VALUES (?, ?, ?)";
+        $stmt = $conn->prepare($sql_encuesta);
+        $stmt->bind_param("ssi", $titulo, $descripcion, $_SESSION['id_usuario']);
+        $stmt->execute();
 
-        $clave_respuestas = 'respuestas_' . ($index + 1);
-        $respuestas = $_POST[$clave_respuestas] ?? [];
+        // OBTENER EL ID DE LA ENCUESTA INSERTADA PARA USARLO EN LAS PREGUNTAS
+        $id_encuesta = $stmt->insert_id;
 
-        //debe de haber entre 2 y 4 respuestas 
+        // ITERAR SOBRE CADA PREGUNTA ENVIADA
+        foreach ($preguntas as $index => $textoPregunta) {
+            // INSERTAR CADA PREGUNTA EN LA TABLA `preguntas`
+            $sql_pregunta = "INSERT INTO preguntas (id_encuesta, texto) VALUES (?, ?)";
+            $stmt_pregunta = $conn->prepare($sql_pregunta);
+            $stmt_pregunta->bind_param("is", $id_encuesta, $textoPregunta);
+            $stmt_pregunta->execute();
 
-        if (count($respuestas) < 2 || count($respuestas) > 4) {
-            die("Cada pregunta debe tener entre 2 y 4 respuestas.");
+            // OBTENER EL ID DE LA PREGUNTA PARA RELACIONAR LAS RESPUESTAS
+            $id_pregunta = $stmt_pregunta->insert_id;
+
+            // CONSTRUIR LA CLAVE QUE CONTIENE LAS RESPUESTAS DE ESTA PREGUNTA
+            $clave_respuestas = 'respuestas_' . ($index + 1);
+            $respuestas = $_POST[$clave_respuestas] ?? [];
+
+            // VALIDAR QUE HAYA ENTRE 2 Y 4 RESPUESTAS POR PREGUNTA
+            if (count($respuestas) < 2 || count($respuestas) > 4) {
+                // LANZAR UNA EXCEPCION PARA DETENER TODO Y HACER ROLLBACK
+                throw new Exception("Cada pregunta debe tener entre 2 y 4 respuestas.");
+            }
+
+            // INSERTAR CADA RESPUESTA EN LA TABLA `respuestas`
+            foreach ($respuestas as $textoRespuesta) {
+                $sql_resp = "INSERT INTO respuestas (id_pregunta, texto) VALUES (?, ?)";
+                $stmt_resp = $conn->prepare($sql_resp);
+                $stmt_resp->bind_param("is", $id_pregunta, $textoRespuesta);
+                $stmt_resp->execute();
+            }
         }
 
-        foreach ($respuestas as $textoRespuesta) {
-            $sql_resp = "INSERT INTO respuestas (id_pregunta, texto) VALUES (?, ?)";
-            $stmt_resp = $conn->prepare($sql_resp);
-            $stmt_resp->bind_param("is", $id_pregunta, $textoRespuesta);
-            $stmt_resp->execute();
-        }
-    }
+        // SI TODO FUE EXITOSO, CONFIRMAMOS LA TRANSACCION
+        $conn->commit();
 
-    header("Location: ../inicio/index.php");
-    exit();
+        // REDIRIGIMOS AL INICIO
+        header("Location: ../inicio/index.php");
+        exit();
+
+    } catch (Exception $e) {
+        // SI OCURRE ALGUN ERROR, CANCELAMOS TODA LA TRANSACCION
+        $conn->rollback();
+
+        // MOSTRAMOS UN MENSAJE DE ERROR Y DETENEMOS LA EJECUCION
+        die("Ocurrió un error al guardar la encuesta: " . $e->getMessage());
     }
+}
 ?>

--- a/crear_encuesta/procesar_crear.php
+++ b/crear_encuesta/procesar_crear.php
@@ -79,8 +79,8 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
         // SI OCURRE ALGUN ERROR, CANCELAMOS TODA LA TRANSACCION
         $conn->rollback();
 
-        // MOSTRAMOS UN MENSAJE DE ERROR Y DETENEMOS LA EJECUCION
-        die("Ocurrió un error al guardar la encuesta: " . $e->getMessage());
+        // REDIRIGIMOS AL INICIO EN CASO DE FALLO
+        header("Location: ../inicio/index.php");
     }
 }
 ?>


### PR DESCRIPTION
# Principios de Atomicidad en la Creación de Encuestas

En este PR se aplican los principios de **atomicidad** a la lógica de creación de encuestas, con el objetivo de evitar inconsistencias en la base de datos en caso de errores durante el proceso de inserción.

## Cambios realizados

- Se inicia una transacción al comenzar el proceso de creación:
  ```php
  $conn->begin_transaction();
  ```
- Todas las operaciones de inserción se envuelven en un bloque try-catch para manejar posibles errores:

  ```php
  try {
      // INSERCIONES A LA BASE DE DATOS...
  } catch (Exception $e) {
      // SI OCURRE ALGUN ERROR, CANCELAMOS TODA LA TRANSACCION
      $conn->rollback();
  
      // MOSTRAMOS UN MENSAJE DE ERROR 
      die("Ocurrió un error al guardar la encuesta: " . $e->getMessage());
  }
  ```

- Si todas las operaciones se ejecutan correctamente, se confirma la transacción:
  ```php
  $conn->commit();
  // REDIRIGIMOS AL INICIO
  header("Location: ../inicio/index.php");
  exit();
  ```
